### PR TITLE
Handle exception in the setupAndStartRecognizing

### DIFF
--- a/ios/Voice/Voice.m
+++ b/ios/Voice/Voice.m
@@ -235,7 +235,13 @@ RCT_EXPORT_METHOD(startSpeech:(NSString*)localeStr callback:(RCTResponseSenderBl
                 [self sendResult:RCTMakeError(@"Speech recognition restricted on this device", nil, nil) :nil :nil :nil];
                 break;
             case SFSpeechRecognizerAuthorizationStatusAuthorized:
-                [self setupAndStartRecognizing:localeStr];
+                @try {
+                    [self setupAndStartRecognizing:localeStr];
+                }
+                @catch (NSException *e) {
+                    NSString *errorMessage = [NSString stringWithFormat:@"%@ - %@", [e name], [e reason]];
+                    [self sendResult:RCTMakeError(errorMessage, nil, nil) :nil :nil :nil];
+                }
                 break;
         }
     }];


### PR DESCRIPTION
### Issue
* It closes https://github.com/hayanmind/mimiking-rn/issues/980

### Solution
* I can't find the exact reason for this bug. Thus, I handle the exception of the related method to prevent crash app.